### PR TITLE
Fix getUrl method returning void when url relationship is not present

### DIFF
--- a/src/Traits/HasUrl.php
+++ b/src/Traits/HasUrl.php
@@ -100,6 +100,7 @@ trait HasUrl
         if ($this->url && $this->url->exists) {
             return url($this->url->url, [], $secure);
         }
+        return null;
     }
 
     /**


### PR DESCRIPTION
In situation where url object is not present (e.g. package attached after initial import of items) the function will throw a fatal because there is no return statement but method is waiting for ?string as return type.